### PR TITLE
Fixed that the weapon upgrade level wasn't displayed

### DIFF
--- a/output/lua/Combat/FileHooks/Post/Player_Client.lua
+++ b/output/lua/Combat/FileHooks/Post/Player_Client.lua
@@ -47,7 +47,7 @@ function PlayerUI_GetWeaponLevel()
     local self = Client.GetLocalPlayer()
 
     local level = 0
-    local upgrades = self:GetUpgrades()
+    local upgrades = self:GetPlayerUpgrades()
     for i = 1, #upgrades do
         local upgradeId = upgrades[i]
 


### PR DESCRIPTION
It didn't work because I forgot to rename the method used.